### PR TITLE
chore(ci): refine branch name validation in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
             exit 0
           fi
           
-          if [[ "$BRANCH_NAME" == "dependabot/*" || "$BRANCH_NAME" == feature!/* || "$BRANCH_NAME" == feature/* || "$BRANCH_NAME" == chore/* || "$BRANCH_NAME" == fix/* || "$BRANCH_NAME" == bugfix/* ]]; then
+          if [[ "$BRANCH_NAME" == dependabot/* || "$BRANCH_NAME" == feature!/* || "$BRANCH_NAME" == feature/* || "$BRANCH_NAME" == chore/* || "$BRANCH_NAME" == fix/* || "$BRANCH_NAME" == bugfix/* ]]; then
             echo "Branch name is valid: $BRANCH_NAME"
             exit 0
           else


### PR DESCRIPTION
Updated the branch name validation logic in the CI/CD workflow to remove unnecessary quotes around the "dependabot/" prefix, ensuring cleaner syntax.

## Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 